### PR TITLE
大佬，发现您的项目引入了org.apache.struts:struts2-core@2.5.22组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>groupId</groupId>
@@ -92,7 +90,7 @@
         <dependency>
             <groupId>org.apache.struts</groupId>
             <artifactId>struts2-core</artifactId>
-            <version>2.5.22</version>
+            <version>2.5.26</version>
         </dependency>
         <dependency>
             <groupId>org.freemarker</groupId>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Struts远程代码执行漏洞
缺陷组件：org.apache.struts:struts2-core@2.5.22
漏洞编号：CVE-2020-17530
漏洞描述：Apache Struts是美国阿帕奇（Apache）软件基金会负责维护的一个开源项目，是一套用于创建企业级Java Web应用的开源MVC框架，主要提供两个版本框架产品，Struts 1和Struts 2。
Apache Struts存在远程代码执行漏洞。攻击者可通过精心构造的请求执行远程代码。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2020-69833
影响范围：[2.0.0, 2.5.26)
最小修复版本：2.5.26
缺陷组件引入路径：groupId:ssh_crm@1.0-SNAPSHOT->org.apache.struts:struts2-core@2.5.22
```
另外我运行这个项目时，IDE的安全插件提示还有7个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=p569b3